### PR TITLE
Add Foundry v13 math.js bridge module

### DIFF
--- a/_mathjs-bridge/LICENSE
+++ b/_mathjs-bridge/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Felipe-Alves-VNGX
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/_mathjs-bridge/README.md
+++ b/_mathjs-bridge/README.md
@@ -1,0 +1,39 @@
+# Math.js Bridge (Foundry v13)
+
+## Objetivo
+Este módulo carrega a biblioteca [math.js](https://mathjs.org/) no navegador do Foundry VTT e expõe a variável global `window.math` para que outros módulos e sistemas possam utilizá-la.
+
+## Compatibilidade
+- **Versão mínima do Foundry VTT**: 12
+- **Versão verificada**: 13
+
+## Instalação manual
+1. Baixe ou clone este repositório.
+2. Copie a pasta `_mathjs-bridge` para o diretório `Data/modules/` da sua instalação do Foundry VTT, mantendo o nome da pasta.
+3. Inicie o Foundry VTT, abra o mundo desejado e acesse **Configuration and Setup → Manage Modules**.
+4. Ative o módulo **Math.js Bridge (Foundry v13)** e recarregue o mundo se solicitado.
+
+## Teste rápido
+Após ativar o módulo, abra o console do navegador (F12) dentro do Foundry VTT e execute:
+
+```js
+console.log(math.pi);
+console.log(math.sqrt(16));
+```
+
+Você deverá ver o valor de π e o resultado da raiz quadrada de 16.
+
+## Substituição do stub
+Para uso em produção, substitua o conteúdo de `math.min.js` pelo build oficial de browser da math.js (arquivo único), disponível em <https://mathjs.org/download.html>. Não é necessário alterar o `shim.js`.
+
+## Possíveis conflitos
+Se outro módulo definir `window.math`, o último script carregado prevalecerá. Certifique-se de ativar apenas um módulo que exponha essa variável global para evitar comportamentos inesperados.
+
+## Atualizando a compatibilidade
+Ao testar este módulo em novas versões do Foundry VTT, ajuste o campo `compatibility.verified` em `module.json` para refletir a versão mais recente com a qual você confirmou o funcionamento.
+
+## Suporte
+- Página oficial do math.js: <https://mathjs.org>
+- Repositório deste módulo: <https://mathjs.org>
+
+Contribuições são bem-vindas!

--- a/_mathjs-bridge/math.min.js
+++ b/_mathjs-bridge/math.min.js
@@ -1,0 +1,9 @@
+/* STUB de fallback — substitua pelo build oficial de browser de math.js */
+/* Substitua este stub pelo build oficial de browser da math.js (arquivo único) baixado do site do projeto. Em ambientes offline, este stub mínimo permite validar a carga do módulo. */
+var math = (function(){
+  const m = {};
+  m.pi = 3.141592653589793;
+  m.sqrt = function(x){ return Math.sqrt(x); };
+  m.evaluate = function(expr){ return Function("'use strict'; return (" + expr + ")")(); };
+  return m;
+})();

--- a/_mathjs-bridge/module.json
+++ b/_mathjs-bridge/module.json
@@ -1,0 +1,22 @@
+{
+  "id": "_mathjs-bridge",
+  "title": "Math.js Bridge (Foundry v13)",
+  "description": "Carrega math.js no navegador e expõe window.math para outros módulos.",
+  "version": "1.0.0",
+  "compatibility": {
+    "minimum": "12",
+    "verified": "13"
+  },
+  "authors": [
+    {
+      "name": "Felipe (bridge)"
+    }
+  ],
+  "url": "https://mathjs.org",
+  "readme": "README.md",
+  "license": "LICENSE",
+  "esmodules": [
+    "math.min.js",
+    "shim.js"
+  ]
+}

--- a/_mathjs-bridge/shim.js
+++ b/_mathjs-bridge/shim.js
@@ -1,0 +1,10 @@
+/* Exposição defensiva da global window.math */
+(() => {
+  if (typeof window !== "undefined") {
+    if (typeof window.math === "undefined" && typeof globalThis !== "undefined" && typeof globalThis.math !== "undefined") {
+      window.math = globalThis.math;
+    } else if (typeof window.math === "undefined" && typeof math !== "undefined") {
+      window.math = math;
+    }
+  }
+})();


### PR DESCRIPTION
## Summary
- add Foundry VTT module manifest that loads math.js then shims it to window.math
- include stubbed math.min.js browser build placeholder and documentation for replacement
- document installation, testing, licensing, and compatibility guidance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68caf066e7688327b2bd7a3edd5443bf