### PR TITLE
Add manifest metadata to module manifest

### DIFF
--- a/module.json
+++ b/module.json
@@ -13,6 +13,9 @@
     }
   ],
   "url": "https://mathjs.org",
+  "manifest": "https://raw.githubusercontent.com/Felipe-Alves-VNGX/mathjs-lib-foundry-v13/main/module.json",
+  "download": "https://github.com/Felipe-Alves-VNGX/mathjs-lib-foundry-v13/archive/refs/heads/main.zip",
+  "manifestPlusVersion": "1.2.0",
   "readme": "README.md",
   "license": "LICENSE",
   "esmodules": [


### PR DESCRIPTION
## Summary
- add manifest and download URLs to the module manifest for Foundry VTT installation
- record the Manifest+ specification version supported by the manifest

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68caf84241f483278a1ab4a868378307